### PR TITLE
オドメトリ算出式及びパラメータ(w_rate , gain)の修正

### DIFF
--- a/launch/vmecanumrover.launch
+++ b/launch/vmecanumrover.launch
@@ -47,7 +47,11 @@
               joint_state_controller"/>
 
   <node name="vmecanum_twist" pkg="mecanumrover_samples" type="vmecanum_twist" output="screen">
-    <param name="gain" value="16.5"/>
+    <!-- gain 16.5 : cmd_vel 1[m/s] -> about 1.2[m/s] -->
+    <!-- <param name="gain" value="16.5"/> -->
+
+    <!-- 16.5 * 1.0/1.2 = 13.75 -->
+    <param name="gain" value="13.75"/>
     <param name="rover_d" value="$(arg rover_d)"/>
     <param name="rover_hb" value="$(arg rover_hb)"/>
     <param name="f_l" value="$(arg f_l)"/>

--- a/launch/vmecanumrover.launch
+++ b/launch/vmecanumrover.launch
@@ -6,7 +6,11 @@
 
   <arg name="rover_d" default="0.133" />
   <arg name="rover_hb" default="0.115" />
-  <arg name="w_rate" default="0.0525" />
+
+  <!-- <arg name="w_rate" default="0.0525" /> -->
+  <!-- wheel + barrel = 0.157[mm] -->
+  <arg name="w_rate" default="0.0785" />
+
   <arg name="f_l" default="0" />
   <arg name="f_r" default="1" />
   <arg name="r_l" default="2" />

--- a/src/vmecanum_odom.cpp
+++ b/src/vmecanum_odom.cpp
@@ -5,12 +5,20 @@
 #include <math.h>
 //#include "mecanumrover.h"
 
+// odometry reference : https://www.researchgate.net/publication/315058609_Modelling_of_Dynamics_of_a_Wheeled_Mobile_Robot_with_Mecanum_Wheels_with_the_use_of_Lagrange_Equations_of_the_Second_Kind
+
+// wheel + barrel = 157[mm] ?
+float wheel_radius = 0.157/2; // 0.0785f
 
 float wheel_speed[4] = { 0 };
-float w_rate=0.0525f;
+//float w_rate=0.0525f;
+
+float w_rate=wheel_radius;
+
 void state0_callback(const control_msgs::JointControllerState& state_msg)
 {
   wheel_speed[0] = state_msg.process_value*w_rate;
+  // ROS_INFO_STREAM(state_msg.process_value << " x " << w_rate << " = " << wheel_speed[0]);
 }
 void state1_callback(const control_msgs::JointControllerState& state_msg)
 {

--- a/src/vmecanum_odom.cpp
+++ b/src/vmecanum_odom.cpp
@@ -60,11 +60,11 @@ int main(int argc, char** argv)
 
     geometry_msgs::Twist rover_odo;
 
-    rover_odo.linear.x  = ((wheel_speed[F_R] + wheel_speed[R_R] + -1.0*(wheel_speed[F_L] + wheel_speed[R_L]))/4.0);
-    rover_odo.linear.y  = ((wheel_speed[F_R] + -1.0*wheel_speed[R_R] + wheel_speed[F_L] + -1.0*wheel_speed[R_L]))/4.0;
+    rover_odo.linear.x  = (-wheel_speed[F_L] - wheel_speed[R_L] + wheel_speed[R_R] + wheel_speed[F_R])/4.0;
+    rover_odo.linear.y = (wheel_speed[F_L] - wheel_speed[R_L] - wheel_speed[R_R] + wheel_speed[F_R])/4.0;
 
     double dCenter2Wheel = ROVER_D + ROVER_HB;
-    rover_odo.angular.z = (atan(wheel_speed[F_L]/dCenter2Wheel) + atan(wheel_speed[F_R]/dCenter2Wheel) + atan(wheel_speed[R_L]/dCenter2Wheel) + atan(wheel_speed[R_R]/dCenter2Wheel))/4.0;
+    rover_odo.angular.z = (wheel_speed[F_L] + wheel_speed[R_L] + wheel_speed[R_R] + wheel_speed[F_R])/(4.0 * dCenter2Wheel);
 
     odom_pub.publish(rover_odo);
 

--- a/src/vmecanum_odom.cpp
+++ b/src/vmecanum_odom.cpp
@@ -7,13 +7,13 @@
 
 // odometry reference : https://www.researchgate.net/publication/315058609_Modelling_of_Dynamics_of_a_Wheeled_Mobile_Robot_with_Mecanum_Wheels_with_the_use_of_Lagrange_Equations_of_the_Second_Kind
 
-// wheel + barrel = 157[mm] ?
-float wheel_radius = 0.157/2; // 0.0785f
-
 float wheel_speed[4] = { 0 };
+
 //float w_rate=0.0525f;
 
-float w_rate=wheel_radius;
+// wheel + barrel = 157[mm]
+// correct w_rate = 0.157/2 = 0.0785
+float w_rate=0.0785f;
 
 void state0_callback(const control_msgs::JointControllerState& state_msg)
 {

--- a/src/vmecanum_twist.cpp
+++ b/src/vmecanum_twist.cpp
@@ -8,7 +8,12 @@
 
 geometry_msgs::Twist twist_last;
 bool twist_enable;
-float gain=21;
+
+//float gain=21;
+
+// gain 16.5 : cmd_vel 1[m/s] -> about 1.2[m/s] 
+// correct gain : 16.5 * 1.0/1.2 = 13.75
+float gain = 13.75;
 
 void twist_stamped_callback(const geometry_msgs::Twist& twist_msg)
 {

--- a/urdf/vmecanumrover.xacro
+++ b/urdf/vmecanumrover.xacro
@@ -704,6 +704,13 @@
       <legacyModeNS>true</legacyModeNS>
       <odometryFrame>map</odometryFrame>
     </plugin>
+
+    <plugin name="ground_truth" filename="libgazebo_ros_p3d.so">
+      <frameName>world</frameName>
+      <bodyName>base_link</bodyName>
+      <topicName>/vmecanumrover/ground_truth</topicName>
+      <updateRate>10.0</updateRate>
+    </plugin>
   </gazebo>
 
 </robot>

--- a/urdf/vmecanumrover.xacro
+++ b/urdf/vmecanumrover.xacro
@@ -705,12 +705,12 @@
       <odometryFrame>map</odometryFrame>
     </plugin>
 
-    <plugin name="ground_truth" filename="libgazebo_ros_p3d.so">
+    <!-- <plugin name="ground_truth" filename="libgazebo_ros_p3d.so">
       <frameName>world</frameName>
       <bodyName>base_link</bodyName>
       <topicName>/vmecanumrover/ground_truth</topicName>
       <updateRate>10.0</updateRate>
-    </plugin>
+    </plugin> -->
   </gazebo>
 
 </robot>

--- a/worlds/sample.world
+++ b/worlds/sample.world
@@ -73,7 +73,7 @@
     <scene>
       <ambient>0.4 0.4 0.4 1</ambient>
       <background>0.7 0.7 0.7 1</background>
-      <shadows>1</shadows>
+      <shadows>0</shadows>
     </scene>
     <audio>
       <device>default</device>

--- a/worlds/sample.world
+++ b/worlds/sample.world
@@ -73,7 +73,7 @@
     <scene>
       <ambient>0.4 0.4 0.4 1</ambient>
       <background>0.7 0.7 0.7 1</background>
-      <shadows>0</shadows>
+      <shadows>1</shadows>
     </scene>
     <audio>
       <device>default</device>


### PR DESCRIPTION
## オドメトリ算出式の修正  

`src/vmecanum_odom.cpp`のオドメトリ算出式が誤っていると思われるため以下の修正を加えました。

```diff
-    rover_odo.angular.z = (atan(wheel_speed[F_L]/dCenter2Wheel) + atan(wheel_speed[F_R]/dCenter2Wheel) + atan(wheel_speed[R_L]/dCenter2Wheel) + atan(wheel_speed[R_R]/dCenter2Wheel))/4.0;
+    rover_odo.angular.z = (wheel_speed[F_L] + wheel_speed[R_L] + wheel_speed[R_R] + wheel_speed[F_R])/(4.0 * dCenter2Wheel);
```

参考  
- [文献](https://www.researchgate.net/publication/315058609_Modelling_of_Dynamics_of_a_Wheeled_Mobile_Robot_with_Mecanum_Wheels_with_the_use_of_Lagrange_Equations_of_the_Second_Kind) (式 2.18)  
- メカナムホイールを有する他のロボットの計算式 : https://github.com/ridgeback/ridgeback/blob/melodic-devel/ridgeback_control/src/odometry.cpp#L94-L101

## w_rateの修正  

Gazebo設定ファイル ( `urdf/vmecanumrover.xacro` )を確認してタイヤ半径（車輪＋バレル込み）が `0.0785`であると判断したため、 ソース及びlaunchのw_rateを `0.0785`に修正しました。  

## gainの修正  

一時的に[gazebo_p3d_plugin](http://gazebosim.org/tutorials?tut=ros_gzplugins)を導入し、以下1[m/s]の速度指令値を与えたときのGazebo上での実速度を確認したところ約1.2[m/s]となっておりました。
その為、現在のgain `16.5` を `16.5 * 1.0/1.2 = 13.75`に修正しました。　

```
$ rostopic pub /rover_twist geometry_msgs/Twist -r 1 -- '[1.0, 0.0, 0.0]' '[0.0, 0.0, 0.0]
```


